### PR TITLE
Add API routes to web server

### DIFF
--- a/accounts-api/AccountsAPI.Tests/AccountsAPI.Tests.csproj
+++ b/accounts-api/AccountsAPI.Tests/AccountsAPI.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />

--- a/accounts-api/AccountsAPI.Tests/TestAPI.cs
+++ b/accounts-api/AccountsAPI.Tests/TestAPI.cs
@@ -21,11 +21,24 @@ public class TestAPI
         Assert.Equal(1, content?.Id);
         Assert.Equal(1, content?.CustomerId);
 
-        result = await client.PostAsJsonAsync("/api/v1/accounts", payload).ConfigureAwait(true);
+        payload.customerId = 2;
+        result = await client
+            .PostAsJsonAsync(new Uri("/api/v1/accounts"), payload)
+            .ConfigureAwait(true);
         content = await result.Content.ReadFromJsonAsync<Account>().ConfigureAwait(true);
 
         Assert.Equal(HttpStatusCode.Created, result.StatusCode);
         Assert.Equal(2, content?.Id);
-        Assert.Equal(1, content?.CustomerId);
+        Assert.Equal(2, content?.CustomerId);
+
+        result = await client.GetAsync(new Uri("/api/v1/accounts")).ConfigureAwait(true);
+        var accountList = await result
+            .Content.ReadFromJsonAsync<List<Account>>()
+            .ConfigureAwait(true);
+
+        Assert.NotNull(accountList);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal(2, accountList.Count);
+        Assert.Contains(new Account { Id = 1, CustomerId = 1 }, accountList);
     }
 }

--- a/accounts-api/AccountsAPI.Tests/TestAPI.cs
+++ b/accounts-api/AccountsAPI.Tests/TestAPI.cs
@@ -56,5 +56,15 @@ public class TestAPI
         result = await client.GetAsync(new Uri("/api/v1/accounts/3")).ConfigureAwait(true);
 
         Assert.Equal(HttpStatusCode.NotFound, result.StatusCode);
+
+        // Fetch all accounts for customer 1
+#pragma warning disable CA2234
+        result = await client.GetAsync("/api/v1/accounts?customerId=1").ConfigureAwait(true);
+        accountList = await result.Content.ReadFromJsonAsync<List<Account>>().ConfigureAwait(true);
+
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.NotNull(accountList);
+        Assert.Single(accountList);
+        Assert.Equal(1, accountList[0].CustomerId);
     }
 }

--- a/accounts-api/AccountsAPI.Tests/TestAPI.cs
+++ b/accounts-api/AccountsAPI.Tests/TestAPI.cs
@@ -66,5 +66,34 @@ public class TestAPI
         Assert.NotNull(accountList);
         Assert.Single(accountList);
         Assert.Equal(1, accountList[0].CustomerId);
+
+        // Delete account 1 and assert it is gone
+        result = await client.DeleteAsync(new Uri("/api/v1/accounts/1")).ConfigureAwait(true);
+
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+
+        result = await client.GetAsync(new Uri("/api/v1/accounts")).ConfigureAwait(true);
+        accountList = await result.Content.ReadFromJsonAsync<List<Account>>().ConfigureAwait(true);
+
+        Assert.NotNull(accountList);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Single(accountList);
+        Assert.DoesNotContain(new Account { Id = 1, CustomerId = 1 }, accountList);
+
+        // Deleting an account that does not exist returns a 404
+        result = await client.DeleteAsync(new Uri("/api/v1/accounts/10")).ConfigureAwait(true);
+        Assert.Equal(HttpStatusCode.NotFound, result.StatusCode);
+
+        // Delete accounts by customer ID
+#pragma warning disable CA2234
+        result = await client.DeleteAsync("/api/v1/accounts?customerId=2").ConfigureAwait(true);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+
+        result = await client.GetAsync(new Uri("/api/v1/accounts")).ConfigureAwait(true);
+        accountList = await result.Content.ReadFromJsonAsync<List<Account>>().ConfigureAwait(true);
+
+        Assert.NotNull(accountList);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Empty(accountList);
     }
 }

--- a/accounts-api/AccountsAPI.Tests/TestAPI.cs
+++ b/accounts-api/AccountsAPI.Tests/TestAPI.cs
@@ -1,0 +1,31 @@
+namespace AccountsAPI.Tests;
+
+using System.Net;
+using Accounts.APIV1;
+using Accounts.Store;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+public class TestAPI
+{
+    [Fact]
+    public async Task TestAccountsEndpoints()
+    {
+        using var application = new WebApplicationFactory<Program>();
+        using var client = application.CreateClient();
+        var payload = new CreateAccountBody { customerId = 1 };
+
+        var result = await client.PostAsJsonAsync("/api/v1/accounts", payload).ConfigureAwait(true);
+        var content = await result.Content.ReadFromJsonAsync<Account>().ConfigureAwait(true);
+
+        Assert.Equal(HttpStatusCode.Created, result.StatusCode);
+        Assert.Equal(1, content?.Id);
+        Assert.Equal(1, content?.CustomerId);
+
+        result = await client.PostAsJsonAsync("/api/v1/accounts", payload).ConfigureAwait(true);
+        content = await result.Content.ReadFromJsonAsync<Account>().ConfigureAwait(true);
+
+        Assert.Equal(HttpStatusCode.Created, result.StatusCode);
+        Assert.Equal(2, content?.Id);
+        Assert.Equal(1, content?.CustomerId);
+    }
+}

--- a/accounts-api/AccountsAPI.Tests/TestAPI.cs
+++ b/accounts-api/AccountsAPI.Tests/TestAPI.cs
@@ -12,8 +12,9 @@ public class TestAPI
     {
         using var application = new WebApplicationFactory<Program>();
         using var client = application.CreateClient();
-        var payload = new CreateAccountBody { customerId = 1 };
 
+        // Create an account for Customer 1
+        var payload = new CreateAccountBody { customerId = 1 };
         var result = await client.PostAsJsonAsync("/api/v1/accounts", payload).ConfigureAwait(true);
         var content = await result.Content.ReadFromJsonAsync<Account>().ConfigureAwait(true);
 
@@ -21,6 +22,7 @@ public class TestAPI
         Assert.Equal(1, content?.Id);
         Assert.Equal(1, content?.CustomerId);
 
+        // Create an account for Customer 2
         payload.customerId = 2;
         result = await client
             .PostAsJsonAsync(new Uri("/api/v1/accounts"), payload)
@@ -31,6 +33,7 @@ public class TestAPI
         Assert.Equal(2, content?.Id);
         Assert.Equal(2, content?.CustomerId);
 
+        // Fetch all accounts and assert we have 2
         result = await client.GetAsync(new Uri("/api/v1/accounts")).ConfigureAwait(true);
         var accountList = await result
             .Content.ReadFromJsonAsync<List<Account>>()
@@ -40,5 +43,18 @@ public class TestAPI
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         Assert.Equal(2, accountList.Count);
         Assert.Contains(new Account { Id = 1, CustomerId = 1 }, accountList);
+
+        // Fetch the second created account and assert it belongs to customer 2
+        result = await client.GetAsync(new Uri("/api/v1/accounts/2")).ConfigureAwait(true);
+        var account = await result.Content.ReadFromJsonAsync<Account>().ConfigureAwait(true);
+
+        Assert.NotNull(account);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal(2, account.CustomerId);
+
+        // Fetch an account that does not exist and assert it returns a 404
+        result = await client.GetAsync(new Uri("/api/v1/accounts/3")).ConfigureAwait(true);
+
+        Assert.Equal(HttpStatusCode.NotFound, result.StatusCode);
     }
 }

--- a/accounts-api/AccountsAPI/APIV1.cs
+++ b/accounts-api/AccountsAPI/APIV1.cs
@@ -1,5 +1,6 @@
 using Accounts.Store;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Accounts.APIV1;
 
@@ -11,10 +12,21 @@ public static class AccountsAPIV1
         return TypedResults.Created($"/api/v1/accounts/{account.Id}", account);
     }
 
-    static Ok<ICollection<Account>> GetAccounts(IStore store)
+    static Ok<ICollection<Account>> GetAccounts(
+        [FromQuery(Name = "customerId")] int? customerId,
+        IStore store
+    )
     {
-        var accounts = store.GetAll();
-        return TypedResults.Ok(accounts);
+        if (customerId is int id)
+        {
+            var accounts = store.GetByCustomerId(id);
+            return TypedResults.Ok(accounts);
+        }
+        else
+        {
+            var accounts = store.GetAll();
+            return TypedResults.Ok(accounts);
+        }
     }
 
     static IResult GetAccountById(int id, IStore store)

--- a/accounts-api/AccountsAPI/APIV1.cs
+++ b/accounts-api/AccountsAPI/APIV1.cs
@@ -17,6 +17,17 @@ public static class AccountsAPIV1
         return TypedResults.Ok(accounts);
     }
 
+    static IResult GetAccountById(int id, IStore store)
+    {
+        var account = store.GetById(id);
+        if (account is null)
+        {
+            return Results.NotFound();
+        }
+
+        return Results.Ok(account);
+    }
+
     public static RouteGroupBuilder MapAccountsAPI(this RouteGroupBuilder group)
     {
         group
@@ -30,6 +41,7 @@ public static class AccountsAPIV1
 
                 return generatedOperation;
             });
+
         group
             .MapGet("/", GetAccounts)
             .WithName("GetAccounts")
@@ -40,6 +52,19 @@ public static class AccountsAPIV1
 
                 return generatedOperation;
             });
+
+        group
+            .MapGet("/{id}", GetAccountById)
+            .WithName("GetAccountById")
+            .WithOpenApi(generatedOperation =>
+            {
+                generatedOperation.Summary = "Fetch an account by its ID.";
+                generatedOperation.Description =
+                    "Fetch an account with the provided ID. Returns a 404 status code if the account does not exist.";
+
+                return generatedOperation;
+            });
+
         return group;
     }
 }

--- a/accounts-api/AccountsAPI/APIV1.cs
+++ b/accounts-api/AccountsAPI/APIV1.cs
@@ -1,0 +1,34 @@
+using Accounts.Store;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Accounts.APIV1;
+
+public static class AccountsAPIV1
+{
+    static Created<Account> CreateAccount(CreateAccountBody body, IStore store)
+    {
+        var account = store.Create(body.customerId);
+        return TypedResults.Created($"/api/v1/accounts/{account.Id}", account);
+    }
+
+    public static RouteGroupBuilder MapAccountsAPI(this RouteGroupBuilder group)
+    {
+        group
+            .MapPost("/", CreateAccount)
+            .WithName("CreateAccount")
+            .WithOpenApi(generatedOperation =>
+            {
+                generatedOperation.Summary = "Create a new account.";
+                generatedOperation.Description =
+                    "Create a new account for a customer with the provided customer ID.";
+
+                return generatedOperation;
+            });
+        return group;
+    }
+}
+
+public record CreateAccountBody
+{
+    public int customerId { get; set; }
+}

--- a/accounts-api/AccountsAPI/APIV1.cs
+++ b/accounts-api/AccountsAPI/APIV1.cs
@@ -75,7 +75,9 @@ public static class AccountsAPIV1
                     "Fetch an account with the provided ID. Returns a 404 status code if the account does not exist.";
 
                 return generatedOperation;
-            });
+            })
+            .Produces<Account>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status404NotFound);
 
         return group;
     }

--- a/accounts-api/AccountsAPI/APIV1.cs
+++ b/accounts-api/AccountsAPI/APIV1.cs
@@ -11,6 +11,12 @@ public static class AccountsAPIV1
         return TypedResults.Created($"/api/v1/accounts/{account.Id}", account);
     }
 
+    static Ok<ICollection<Account>> GetAccounts(IStore store)
+    {
+        var accounts = store.GetAll();
+        return TypedResults.Ok(accounts);
+    }
+
     public static RouteGroupBuilder MapAccountsAPI(this RouteGroupBuilder group)
     {
         group
@@ -21,6 +27,16 @@ public static class AccountsAPIV1
                 generatedOperation.Summary = "Create a new account.";
                 generatedOperation.Description =
                     "Create a new account for a customer with the provided customer ID.";
+
+                return generatedOperation;
+            });
+        group
+            .MapGet("/", GetAccounts)
+            .WithName("GetAccounts")
+            .WithOpenApi(generatedOperation =>
+            {
+                generatedOperation.Summary = "Fetch all accounts.";
+                generatedOperation.Description = "Fetches a list of all accounts that exist.";
 
                 return generatedOperation;
             });

--- a/accounts-api/AccountsAPI/Program.cs
+++ b/accounts-api/AccountsAPI/Program.cs
@@ -1,27 +1,22 @@
+using Accounts.APIV1;
+using Accounts.Store;
+
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddSingleton<IStore>(new InMemoryStore());
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI();
 }
 
-app.MapGet(
-        "/",
-        () =>
-        {
-            return "Hello, world!";
-        }
-    )
-    .WithName("GetRoot")
-    .WithOpenApi();
+app.MapGroup("/api/v1/accounts").MapAccountsAPI();
 
 app.Run();
+
+public partial class Program { }


### PR DESCRIPTION
Adds all the required route handlers to the AccountsAPI web server:

- POST /accounts : create an account
- GET /accounts : fetch all accounts
- GET /accounts/{id} : fetch an account by its id
- GET /accounts?customerId={id} : fetch all accounts belonging to a specific customer
- DELETE /accounts/{id} : delete an account by its id
- DELETE /accounts?customerId={id} : delete all accounts belonging to a specific customer