### PR TITLE
Create in-memory store for transactions API

### DIFF
--- a/transactions-api/TransactionsAPI.Tests/TestInMemoryStore.cs
+++ b/transactions-api/TransactionsAPI.Tests/TestInMemoryStore.cs
@@ -1,0 +1,32 @@
+using Transactions.Store;
+
+namespace TransactionsAPI.Tests;
+
+public class TestInMemoryStore
+{
+    InMemoryStore store;
+
+    public TestInMemoryStore()
+    {
+        store = new InMemoryStore();
+    }
+
+    [Fact(DisplayName = "Create transactions for account IDs")]
+    public void CreateNewTransactions()
+    {
+        var transaction = store.Create(1, 10);
+        Assert.Equal(1, transaction.Id);
+        Assert.Equal(1, transaction.AccountId);
+        Assert.Equal(10, transaction.Amount);
+
+        transaction = store.Create(1, 20);
+        Assert.Equal(2, transaction.Id);
+        Assert.Equal(1, transaction.AccountId);
+        Assert.Equal(20, transaction.Amount);
+
+        transaction = store.Create(2, 10);
+        Assert.Equal(3, transaction.Id);
+        Assert.Equal(2, transaction.AccountId);
+        Assert.Equal(10, transaction.Amount);
+    }
+}

--- a/transactions-api/TransactionsAPI.Tests/TestInMemoryStore.cs
+++ b/transactions-api/TransactionsAPI.Tests/TestInMemoryStore.cs
@@ -29,4 +29,22 @@ public class TestInMemoryStore
         Assert.Equal(2, transaction.AccountId);
         Assert.Equal(10, transaction.Amount);
     }
+
+    [Fact(DisplayName = "Fetch all transactions for a specific account")]
+    public void GetTransactionsByAccountId()
+    {
+        var expectedAccount1Transactions = new List<Transaction>
+        {
+            store.Create(1, 10),
+            store.Create(1, 20),
+        };
+
+        var expectedAccount2Transactions = new List<Transaction> { store.Create(2, 30) };
+
+        var gotAccount1Transactions = store.GetByAccountId(1);
+        Assert.Equal(expectedAccount1Transactions, gotAccount1Transactions);
+
+        var gotAccount2Transactions = store.GetByAccountId(2);
+        Assert.Equal(expectedAccount2Transactions, gotAccount2Transactions);
+    }
 }

--- a/transactions-api/TransactionsAPI.Tests/TestInMemoryStore.cs
+++ b/transactions-api/TransactionsAPI.Tests/TestInMemoryStore.cs
@@ -47,4 +47,20 @@ public class TestInMemoryStore
         var gotAccount2Transactions = store.GetByAccountId(2);
         Assert.Equal(expectedAccount2Transactions, gotAccount2Transactions);
     }
+
+    [Fact(DisplayName = "Delete all transactions for a specific account")]
+    public void DeleteTransactionsByAccountId()
+    {
+        store.Create(1, 10);
+        store.Create(1, 20);
+        store.Create(2, 30);
+
+        Assert.Equal(2, store.GetByAccountId(1).Count);
+        Assert.Single(store.GetByAccountId(2));
+
+        store.DeleteByAccountId(1);
+
+        Assert.Single(store.GetByAccountId(2));
+        Assert.Empty(store.GetByAccountId(1));
+    }
 }

--- a/transactions-api/TransactionsAPI.Tests/UnitTest1.cs
+++ b/transactions-api/TransactionsAPI.Tests/UnitTest1.cs
@@ -1,7 +1,0 @@
-namespace TransactionsAPI.Tests;
-
-public class UnitTest1
-{
-    [Fact]
-    public void Test1() { }
-}

--- a/transactions-api/TransactionsAPI/Store.cs
+++ b/transactions-api/TransactionsAPI/Store.cs
@@ -28,6 +28,13 @@ public interface IStore
     /// <param name="amount">Value of the transaction.</param>
     /// <returns>A newly created <c>Transaction</c>.</returns>
     Transaction Create(int accountId, int amount);
+
+    /// <summary>
+    /// Fetch all <c>Transaction</c>s belonging to a specific account.
+    /// </summary>
+    /// <param name="accountId">ID of the account of which the transactions should be fetched.</param>
+    /// <returns>All <c>Transaction</c>s belonging to the account.</returns>
+    ICollection<Transaction> GetByAccountId(int accountId);
 }
 
 public class InMemoryStore : IStore
@@ -52,5 +59,10 @@ public class InMemoryStore : IStore
         };
         _transactions = _transactions.Append(newTransaction).ToList();
         return newTransaction;
+    }
+
+    public ICollection<Transaction> GetByAccountId(int accountId)
+    {
+        return _transactions.FindAll(t => t.AccountId == accountId).ToList();
     }
 }

--- a/transactions-api/TransactionsAPI/Store.cs
+++ b/transactions-api/TransactionsAPI/Store.cs
@@ -35,6 +35,13 @@ public interface IStore
     /// <param name="accountId">ID of the account of which the transactions should be fetched.</param>
     /// <returns>All <c>Transaction</c>s belonging to the account.</returns>
     ICollection<Transaction> GetByAccountId(int accountId);
+
+    /// <summary>
+    /// Delete all <c>Transaction</c>s belonging to an account with the provided
+    /// ID.
+    /// </summary>
+    /// <param name="accountId">ID of the account of which the transactions should be deleted.</param>
+    void DeleteByAccountId(int accountId);
 }
 
 public class InMemoryStore : IStore
@@ -64,5 +71,10 @@ public class InMemoryStore : IStore
     public ICollection<Transaction> GetByAccountId(int accountId)
     {
         return _transactions.FindAll(t => t.AccountId == accountId).ToList();
+    }
+
+    public void DeleteByAccountId(int accountId)
+    {
+        _transactions = _transactions.FindAll(t => t.AccountId != accountId);
     }
 }

--- a/transactions-api/TransactionsAPI/Store.cs
+++ b/transactions-api/TransactionsAPI/Store.cs
@@ -1,0 +1,56 @@
+namespace Transactions.Store;
+
+/// <summary>
+/// A <c>Transaction</c> represents a monetary transaction for a specific
+/// account.
+/// </summary>
+/// <param name="Id">ID of the transaction.</param>
+/// <param name="AccountId">ID of the account the transaction belongs to.</param>
+/// <param name="Amount">Monetary value of the transaction.</param>
+public record Transaction
+{
+    public int Id { get; set; }
+    public int AccountId { get; set; }
+    public int Amount { get; set; }
+}
+
+/// <summary>
+/// Interface <c>IStore</c> describes an interface that allows creating,
+/// fetching, and delete a collection of <c>Transaction</c> records.
+/// </summary>
+public interface IStore
+{
+    /// <summary>
+    /// Create and store a new <c>Transaction</c> for the provided account with
+    /// the provided amount and return it.
+    /// </summary>
+    /// <param name="accountId">ID of the account the transaction should belong to.</param>
+    /// <param name="amount">Value of the transaction.</param>
+    /// <returns>A newly created <c>Transaction</c>.</returns>
+    Transaction Create(int accountId, int amount);
+}
+
+public class InMemoryStore : IStore
+{
+    private List<Transaction> _transactions;
+
+    public InMemoryStore()
+    {
+        _transactions = new List<Transaction>();
+    }
+
+    public Transaction Create(int accountId, int amount)
+    {
+        var lastTransaction = _transactions.LastOrDefault();
+        var nextId = lastTransaction is null ? 1 : lastTransaction.Id + 1;
+
+        var newTransaction = new Transaction
+        {
+            Id = nextId,
+            AccountId = accountId,
+            Amount = amount,
+        };
+        _transactions = _transactions.Append(newTransaction).ToList();
+        return newTransaction;
+    }
+}


### PR DESCRIPTION
Adds an in-memory store for the transactions API that allows you to:

- Create a transaction for a given account with the provided amount
- Get all transactions for a given account
- Delete all transactions for a given account