### PR TITLE
Add API routes for transactions service

### DIFF
--- a/transactions-api/TransactionsAPI.Tests/TestAPI.cs
+++ b/transactions-api/TransactionsAPI.Tests/TestAPI.cs
@@ -25,5 +25,37 @@ public class TestAPI
         Assert.Equal(1, content?.Id);
         Assert.Equal(1, content?.AccountId);
         Assert.Equal(10, content?.Amount);
+
+        // Create a transaction for Account 2
+        payload = new CreateTransactionBody { accountId = 2, amount = 20 };
+        result = await client.PostAsJsonAsync("/api/v1/transactions", payload).ConfigureAwait(true);
+        Assert.Equal(HttpStatusCode.Created, result.StatusCode);
+
+        content = await result.Content.ReadFromJsonAsync<Transaction>().ConfigureAwait(true);
+
+        Assert.Equal(2, content?.Id);
+        Assert.Equal(2, content?.AccountId);
+        Assert.Equal(20, content?.Amount);
+
+        // Fetch transactions for Account 2
+#pragma warning disable CA2234
+        result = await client.GetAsync("/api/v1/transactions?accountId=2").ConfigureAwait(true);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+
+        var transactionList = await result
+            .Content.ReadFromJsonAsync<List<Transaction>>()
+            .ConfigureAwait(true);
+
+        Assert.NotNull(transactionList);
+        Assert.Single(transactionList);
+        Assert.Equal(
+            new Transaction
+            {
+                Id = 2,
+                AccountId = 2,
+                Amount = 20,
+            },
+            transactionList[0]
+        );
     }
 }

--- a/transactions-api/TransactionsAPI.Tests/TestAPI.cs
+++ b/transactions-api/TransactionsAPI.Tests/TestAPI.cs
@@ -1,0 +1,29 @@
+namespace TransactionsAPI.Tests;
+
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Transactions.APIV1;
+using Transactions.Store;
+
+public class TestAPI
+{
+    [Fact]
+    public async Task TestTransactionsEndpoints()
+    {
+        using var application = new WebApplicationFactory<Program>();
+        using var client = application.CreateClient();
+
+        // Create a transaction for Account 1
+        var payload = new CreateTransactionBody { accountId = 1, amount = 10 };
+        var result = await client
+            .PostAsJsonAsync("/api/v1/transactions", payload)
+            .ConfigureAwait(true);
+        Assert.Equal(HttpStatusCode.Created, result.StatusCode);
+
+        var content = await result.Content.ReadFromJsonAsync<Transaction>().ConfigureAwait(true);
+
+        Assert.Equal(1, content?.Id);
+        Assert.Equal(1, content?.AccountId);
+        Assert.Equal(10, content?.Amount);
+    }
+}

--- a/transactions-api/TransactionsAPI.Tests/TestAPI.cs
+++ b/transactions-api/TransactionsAPI.Tests/TestAPI.cs
@@ -57,5 +57,42 @@ public class TestAPI
             },
             transactionList[0]
         );
+
+        // Delete transactions for Account 2
+#pragma warning disable CA2234
+        result = await client.DeleteAsync("/api/v1/transactions?accountId=2").ConfigureAwait(true);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+
+#pragma warning disable CA2234
+        result = await client.GetAsync("/api/v1/transactions?accountId=2").ConfigureAwait(true);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+
+        transactionList = await result
+            .Content.ReadFromJsonAsync<List<Transaction>>()
+            .ConfigureAwait(true);
+
+        Assert.NotNull(transactionList);
+        Assert.Empty(transactionList);
+
+        // Assert Account 1's transactions still exist
+#pragma warning disable CA2234
+        result = await client.GetAsync("/api/v1/transactions?accountId=1").ConfigureAwait(true);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+
+        transactionList = await result
+            .Content.ReadFromJsonAsync<List<Transaction>>()
+            .ConfigureAwait(true);
+
+        Assert.NotNull(transactionList);
+        Assert.Single(transactionList);
+        Assert.Equal(
+            new Transaction
+            {
+                Id = 1,
+                AccountId = 1,
+                Amount = 10,
+            },
+            transactionList[0]
+        );
     }
 }

--- a/transactions-api/TransactionsAPI.Tests/TransactionsAPI.Tests.csproj
+++ b/transactions-api/TransactionsAPI.Tests/TransactionsAPI.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />

--- a/transactions-api/TransactionsAPI/APIV1.cs
+++ b/transactions-api/TransactionsAPI/APIV1.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
 using Transactions.Store;
 
 namespace Transactions.APIV1;
@@ -9,6 +10,15 @@ public static class TransactionsAPIV1
     {
         var transaction = store.Create(body.accountId, body.amount);
         return TypedResults.Created($"/api/v1/transactions/{transaction.Id}", transaction);
+    }
+
+    static Ok<ICollection<Transaction>> GetTransactionsByAccountId(
+        [FromQuery(Name = "accountId")] int accountId,
+        IStore store
+    )
+    {
+        var transactions = store.GetByAccountId(accountId);
+        return TypedResults.Ok(transactions);
     }
 
     public static RouteGroupBuilder MapTransactionsAPI(this RouteGroupBuilder group)
@@ -22,6 +32,17 @@ public static class TransactionsAPIV1
                 generatedOperation.Description =
                     "Create a new transaction for an account with the provided amount.";
 
+                return generatedOperation;
+            });
+
+        group
+            .MapGet("/", GetTransactionsByAccountId)
+            .WithName("GetTransactionsByAccountId")
+            .WithOpenApi(generatedOperation =>
+            {
+                generatedOperation.Summary = "Fetch all transactions belonging to an account.";
+                generatedOperation.Description =
+                    "Fetch all transactions that belong to the account with the provided ID.";
                 return generatedOperation;
             });
 

--- a/transactions-api/TransactionsAPI/APIV1.cs
+++ b/transactions-api/TransactionsAPI/APIV1.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Transactions.Store;
+
+namespace Transactions.APIV1;
+
+public static class TransactionsAPIV1
+{
+    static Created<Transaction> CreateTransaction(CreateTransactionBody body, IStore store)
+    {
+        var transaction = store.Create(body.accountId, body.amount);
+        return TypedResults.Created($"/api/v1/transactions/{transaction.Id}", transaction);
+    }
+
+    public static RouteGroupBuilder MapTransactionsAPI(this RouteGroupBuilder group)
+    {
+        group
+            .MapPost("/", CreateTransaction)
+            .WithName("CreateTransaction")
+            .WithOpenApi(generatedOperation =>
+            {
+                generatedOperation.Summary = "Create a new transaction.";
+                generatedOperation.Description =
+                    "Create a new transaction for an account with the provided amount.";
+
+                return generatedOperation;
+            });
+
+        return group;
+    }
+}
+
+public record CreateTransactionBody
+{
+    public int accountId { get; set; }
+    public int amount { get; set; }
+}

--- a/transactions-api/TransactionsAPI/APIV1.cs
+++ b/transactions-api/TransactionsAPI/APIV1.cs
@@ -21,6 +21,15 @@ public static class TransactionsAPIV1
         return TypedResults.Ok(transactions);
     }
 
+    static Ok DeleteTransactionsByAccountId(
+        [FromQuery(Name = "accountId")] int accountId,
+        IStore store
+    )
+    {
+        store.DeleteByAccountId(accountId);
+        return TypedResults.Ok();
+    }
+
     public static RouteGroupBuilder MapTransactionsAPI(this RouteGroupBuilder group)
     {
         group
@@ -43,6 +52,17 @@ public static class TransactionsAPIV1
                 generatedOperation.Summary = "Fetch all transactions belonging to an account.";
                 generatedOperation.Description =
                     "Fetch all transactions that belong to the account with the provided ID.";
+                return generatedOperation;
+            });
+
+        group
+            .MapDelete("/", DeleteTransactionsByAccountId)
+            .WithName("DeleteTransactionsByAccountId")
+            .WithOpenApi(generatedOperation =>
+            {
+                generatedOperation.Summary = "Delete all transactions belonging to an account.";
+                generatedOperation.Description =
+                    "Delete all transactions that belong to the account with the provided ID.";
                 return generatedOperation;
             });
 

--- a/transactions-api/TransactionsAPI/Program.cs
+++ b/transactions-api/TransactionsAPI/Program.cs
@@ -1,6 +1,22 @@
+using Transactions.APIV1;
+using Transactions.Store;
+
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+builder.Services.AddSingleton<IStore>(new InMemoryStore());
+
 var app = builder.Build();
 
-app.MapGet("/", () => "Hello World!");
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.MapGroup("/api/v1/transactions").MapTransactionsAPI();
 
 app.Run();
+
+public partial class Program { }


### PR DESCRIPTION
Adds REST API handlers for the transactions service:

- POST /api/v1/transactions { accountId, amount } - creates a new transaction for the specified account
- GET /api/v1/transactions?accountId - fetches all transactions for the specified account
- DELETE /api/v1/transactions?accountId - deletes all transactions for the specified account